### PR TITLE
QR Code Checkin URLs on WordPress link to backend pages (admin) instead of the frontend page (website)

### DIFF
--- a/qrcodecheckin.php
+++ b/qrcodecheckin.php
@@ -245,7 +245,7 @@ function qrcodecheckin_get_code($participant_id) {
 function qrcodecheckin_get_url($code, $participant_id) {
   $query = NULL;
   $absolute = TRUE;
-  return CRM_Utils_System::url('civicrm/qrcodecheckin/' . $participant_id . '/' . $code, $query, $absolute);
+  return CRM_Utils_System::url('civicrm/qrcodecheckin/' . $participant_id . '/' . $code, $query, $absolute, NULL, TRUE, TRUE);
 }
 
 /**


### PR DESCRIPTION
QR Code Checkin URLs on WordPress link to backend pages (admin) instead of the frontend page (website).

Just need to call CRM_Utils_System::url with explicit parameters to generate a front-end URL.

Agileware Ref: CIVICRM-1839