### PR TITLE
fix permissions for Civi 5.71+

### DIFF
--- a/qrcodecheckin.php
+++ b/qrcodecheckin.php
@@ -218,8 +218,8 @@ function qrcodecheckin_delete_image($code) {
 function qrcodecheckin_civicrm_permission(&$permissions) {
   $prefix = E::ts('QR Code Checkin') . ': ';
   $permissions[QRCODECHECKIN_PERM] = [
-    $prefix . E::ts(QRCODECHECKIN_PERM),
-    E::ts('Access the page presented by the QR Code and click to change participant status to attended'),
+    'label' => $prefix . E::ts(QRCODECHECKIN_PERM),
+    'description' => E::ts('Access the page presented by the QR Code and click to change participant status to attended'),
   ];
 }
 


### PR DESCRIPTION
PR to use the new permission format, supported by Civi 5.0+, with the old method emitting deprecation warnings since 5.71.