### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/Qrcodecheckin/Checkin.php
+++ b/api/v3/Qrcodecheckin/Checkin.php
@@ -20,7 +20,7 @@ function _civicrm_api3_qrcodecheckin_Checkin_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_qrcodecheckin_Checkin($params) {
   // Ensure they have the right permission. NOTE: we bypass normal permissions
@@ -29,11 +29,11 @@ function civicrm_api3_qrcodecheckin_Checkin($params) {
   // simple thing without having to give them privileges to update participants
   // fully.
   if (!CRM_Core_Permission::check(QRCODECHECKIN_PERM) && !CRM_Core_Permission::check('edit event participants')) {
-    throw new API_Exception('You do not have the proper permissions to do this.', 1);
+    throw new CRM_Core_Exception('You do not have the proper permissions to do this.', 1);
   }
 
   if (!array_key_exists('participant_id', $params)) {
-    throw new API_Exception('Please pass participant_id', 1);
+    throw new CRM_Core_Exception('Please pass participant_id', 1);
   }
 
   $returnValues = \Civi\Api4\Participant::update(FALSE)


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.