### PR TITLE
Add option for QR code in confirmation email

### DIFF
--- a/Civi/QRCodeCheckin/EventConfirmTextToken.php
+++ b/Civi/QRCodeCheckin/EventConfirmTextToken.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Civi\QRCodeCheckin;
+use CRM_Qrcodecheckin_ExtensionUtil as E;
+use Civi\Core\Service\AutoService;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Add the QR code to event confirmation email text if the event is configured to do so.
+ *
+ * @service civi.qrcodecheckin.tokens
+ */
+
+class EventConfirmTextToken extends AutoService implements EventSubscriberInterface {
+  public static function getSubscribedEvents() {
+    return [
+      'civi.token.eval' => ['addQrCodetoEventConfirmText', -100],
+    ];
+  }
+
+  public function addQrCodetoEventConfirmText(\Civi\Token\Event\TokenValueEvent $e): void {
+    $activeTokens = $e->getTokenProcessor()->getMessageTokens();
+    if (!in_array('event', array_keys($activeTokens ?? []))) {
+      return;
+    }
+    $eventTokens = $activeTokens['event'] ?? [];
+    if (!in_array('confirm_email_text', $eventTokens)) {
+      return;
+    }
+    $eventId = $e->getTokenProcessor()->context['eventId'];
+    $qrcode_confirmation_events = \Civi::settings()->get('qrcode_confirmation_events');
+    if (!in_array($eventId, $qrcode_confirmation_events ?? [])) {
+      return;
+    }
+
+    foreach ($e->getRows() as $rowNum => $row) {
+      $participantId = $row->tokenProcessor->context['participantId'];
+      $code = qrcodecheckin_get_code($participantId);
+      // First ensure the image file is created.
+      qrcodecheckin_create_image($code, $participantId);
+
+      // Get the absolute link to the image that will display the QR code.
+      $link = qrcodecheckin_get_image_url($code);
+
+      $html = E::ts('<p><img alt="QR Code with link to checkin page" src="%1">You should see a QR code above which will be used to quickly check you into the event. If you do not see a code display above, please enable the display of images in your email program or try accessing it <a href="%1">directly</a>. You may want to take a screen grab of your QR Code in case you need to display it when you do not have Internet access.</p>', [1 => $link]);
+      $originalText = $row->tokenProcessor->rowValues[$rowNum]['text/html']['event']['confirm_email_text'] ?? '';
+      $row->format('text/html')->tokens('event', 'confirm_email_text', $originalText . $html);
+    }
+  }
+
+}

--- a/info.xml
+++ b/info.xml
@@ -29,6 +29,7 @@
     <mixin>setting-php@1.0.0</mixin>
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>smarty@1.0.3</mixin>
+    <mixin>scan-classes@1.0.0</mixin>
   </mixins>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/templates/qrcode-checkin-event-options.tpl
+++ b/templates/qrcode-checkin-event-options.tpl
@@ -7,9 +7,18 @@
       <div class="help">{ts domain="net.ourpowerbase.qrcodecheckin"}If enabled, when sending email to contacts you can include a QR Checkin Code token for this event.{/ts}</div>
     </td>
   </tr>
+  <tr id="qrcode-confirmation-event-tr">
+    <td>&nbsp;</td>
+    <td>
+      {$form.qrcode_confirmation_event.html}
+      {$form.qrcode_confirmation_event.label}
+      <div class="help">{ts domain="net.ourpowerbase.qrcodecheckin"}If enabled, confirmation emails will contain the QR code. Can be used in addition to or instead of tokens.{/ts}</div>
+    </td>
+  </tr>
 </table>
 
 <script type="text/javascript">
     CRM.$('tr#qrcode-enabled-event-tr').insertAfter('tr.crm-event-manage-eventinfo-form-block-is_active');
+    CRM.$('tr#qrcode-confirmation-event-tr').insertAfter('tr#qrcode-enabled-event-tr');
 </script>
 


### PR DESCRIPTION
This adds a new option for the QR code to be added to the bottom of the `event_confirm_text`.  This is an easier option for folks less familiar with Civi, and also for folks who want the initial registration email to contain the QR code.

If this is amenable to you, I can update the docs.