### PR TITLE
Add auto-checkin setting

### DIFF
--- a/CRM/Qrcodecheckin/Page/QrcodecheckinLanding.php
+++ b/CRM/Qrcodecheckin/Page/QrcodecheckinLanding.php
@@ -72,8 +72,19 @@ class CRM_Qrcodecheckin_Page_QrcodecheckinLanding extends CRM_Core_Page {
     $roles = CRM_Core_PseudoConstant::get('CRM_Event_DAO_Participant', 'role_id');
     $this->assign('role', $roles[$dao->role_id]);
 
-    if ($dao->participant_status == 'Registered') {
-      $this->assign('update_button', TRUE);
+    if ($dao->participant_status === 'Registered') {
+      $scanAction = \Civi::settings()->get('qrcode_scan_action');
+      if ($scanAction !== 'autoupdate') {
+        $this->assign('update_button', TRUE);
+      }
+      else {
+        $this->assign('update_button', FALSE);
+        \Civi\Api4\Participant::update(FALSE)
+          ->addWhere('id', '=', $this->participant_id)
+          ->addValue('status_id:name', 'Attended')
+          ->execute();
+      }
+      $this->assign('participant_status', "Was $dao->participant_status, now Attended");
       $this->assign('status_class', 'qrcheckin-status-registered');
     }
     elseif ($dao->participant_status == 'Attended') {

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ With one click, the registration worker can change their status from registered 
 
 The extension is licensed under [AGPL-3.0](LICENSE.txt).
 
+## Setup
+After enabling, go to **Administer » CiviEvent » QR Code Checkin Settings**. Configure the behavior for what occurs when a QR code is scanned.  *Show Button* will provide an "Update to Attended" button.  *Automatically Check In* will update the participant status to "Attended" without further input.
+
 ## Usage
 
 Once enabled, each event configuration screen will have a new checkbox underneath the existing "Is this Event Active?" checkbox:

--- a/info.xml
+++ b/info.xml
@@ -30,6 +30,7 @@
     <mixin>mgd-php@1.0.0</mixin>
     <mixin>smarty@1.0.3</mixin>
     <mixin>scan-classes@1.0.0</mixin>
+    <mixin>setting-admin@1.0.1</mixin>
   </mixins>
   <classloader>
     <psr0 prefix="CRM_" path="."/>

--- a/qrcodecheckin.php
+++ b/qrcodecheckin.php
@@ -310,6 +310,22 @@ function qrcodecheckin_civicrm_tokenValues(&$values, $cids, $job = null, $tokens
 }
 
 /**
+ * Implements hook_civicrm_navigationMenu().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu/
+ */
+function qrcodecheckin_civicrm_navigationMenu(&$menu) {
+    _qrcodecheckin_civix_insert_navigation_menu($menu, 'Administer/CiviEvent', [
+        'label' => E::ts('QR Code Checkin Settings'),
+        'name' => 'qrcodecheckin_settings',
+        'url' => CRM_Utils_System::url('civicrm/admin/setting/qrcode', ['reset' => TRUE]),
+        'permission' => 'administer CiviCRM',
+        'operator' => 'OR',
+        'separator' => 0,
+    ]);
+}
+
+/**
  * Fetch participant_id from contact_id
  */
 function qrcodecheckin_participant_id_for_contact_id($contact_id, $event_id) {

--- a/settings/qrcodecheckin.setting.php
+++ b/settings/qrcodecheckin.setting.php
@@ -8,9 +8,6 @@ use CRM_Qrcodecheckin_ExtensionUtil as E;
 
 return [
   'qrcode_events' => [
-    'group_name' => 'QR Code Checkin',
-    'group' => 'qrcodecheckin',
-    'name' => 'qrcode_events',
     'type' => 'String',
     'serialize' => CRM_Core_DAO::SERIALIZE_JSON,
     'default' => [],
@@ -20,4 +17,22 @@ return [
     'description' => E::ts('The events that will use QRCodes for a given contact (can be more than one event).'),
     'help_text' => E::ts('If enabled, when sending email to contacts you can include a QR Checkin Code token for this event.'),
 	],
+  'qrcode_scan_action' => [
+    'name' => 'qrcode_scan_action',
+    'title' => E::ts('QR Code Scan Action'),
+    'type' => 'String',
+    'html_type' => 'Select',
+    'default' => 'button',
+    'add' => '4.7',
+    'is_domain' => 1,
+    'is_contact' => 0,
+    'description' => E::ts('The action to take when a QR code is scanned.'),
+    'help_text' => E::ts('Choose whether scanning a QR code automatically checks in the participant, or presents an "Attended" button.'),
+    'options' => ['button' => E::ts('Show Button'), 'autoupdate' => E::ts('Automatically Check In')],
+    'settings_pages' => [
+      'qrcode' => [
+        'weight' => 10,
+      ],
+    ],
+  ],
 ];

--- a/xml/Menu/qrcodecheckin.xml
+++ b/xml/Menu/qrcodecheckin.xml
@@ -6,4 +6,10 @@
     <title>QrcodecheckinLanding</title>
     <access_arguments>register for events</access_arguments>
   </item>
+  <item>
+    <path>civicrm/admin/setting/qrcode</path>
+    <title>QR Code Checkin Settings</title>
+    <page_callback>CRM_Admin_Form_Generic</page_callback>
+    <access_arguments>administer CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
* Adds a settings page.
* Adds a setting **QR Code Scan Action**, which either a) preserves current behavior (show button to update participant status) or b) automatically updates the status when the code is scanned.