### PR TITLE
fix QR code checkin permission

### DIFF
--- a/qrcodecheckin.php
+++ b/qrcodecheckin.php
@@ -143,6 +143,12 @@ function qrcodecheckin_civicrm_postProcess($formName, &$form) {
   }
 }
 
+function qrcodecheckin_civicrm_alterAPIPermissions($entity, $action, $params, &$permissions) {
+  $permissions['qrcodecheckin'] = [
+    'checkin' => [QRCODECHECKIN_PERM, 'edit event participants'],
+  ];
+}
+
 /**
  * Create a hash based on the participant id.
  */


### PR DESCRIPTION
The permissions in this extension are correctly checked when the landing page is opened.  However, if you click the "Update to Attended" button, there's another API permission check.  If you're not an administrator, it fails with:

```
{"error_code":"unauthorized","entity":"Qrcodecheckin","action":"checkin","is_error":1,"error_message":"API permission check failed for Qrcodecheckin/checkin call; insufficient permission: require administer CiviCRM"}
```

This PR fixes the permission check on the "Update to Attended" button.