### PR TITLE
Fix public link in participant record

### DIFF
--- a/qrcodecheckin.php
+++ b/qrcodecheckin.php
@@ -227,7 +227,7 @@ function qrcodecheckin_create_image($code, $participant_id) {
     $data = qrcodecheckin_get_image_data($url, $base64);
     file_put_contents($path, $data);
     Participant::update(FALSE)
-      ->addValue('QRCode.QRCode_Public_link', qrcodecheckin_get_image_url($path))
+      ->addValue('QRCode.QRCode_Public_link', qrcodecheckin_get_image_url($code))
       ->addWhere('id', '=', $participant_id)
       ->execute();
   }


### PR DESCRIPTION
The QR code URL that displays in the participant record is incorrect. This is because the full server path is included in the URL. This change fixes this issue.

Before: `https://{DOMAIN}/public/media/qrcodecheckin//var/www/civicrm-standalone/public/media/qrcodecheckin/{HASH}.png.png`

After: `https://{DOMAIN}/public/media/qrcodecheckin/public/media/qrcodecheckin/{HASH}.png`