### PR TITLE
Fix: empty settings cause fatal error

### DIFF
--- a/qrcodecheckin.php
+++ b/qrcodecheckin.php
@@ -84,7 +84,7 @@ function qrcodecheckin_civicrm_buildForm($formName, &$form) {
         'template' => "{$templatePath}/qrcode-checkin-event-options.tpl"
       ]);
 
-      $qrcode_events = \Civi::settings()->get('qrcode_events');
+      $qrcode_events = \Civi::settings()->get('qrcode_events') ?? [];
       $qrcode_confirmation_events = \Civi::settings()->get('qrcode_confirmation_events') ?? [];
       $event_id = intval($form->getVar('_id'));
       if (in_array($event_id, $qrcode_events)) {
@@ -113,7 +113,7 @@ function qrcodecheckin_civicrm_postProcess($formName, &$form) {
     $qrcode_confirmation_event = array_key_exists('qrcode_confirmation_event', $vals) ? TRUE : FALSE;
 
     // Add/Remove event ID to/from array of QR-enabled events as required
-    $qrcode_events = \Civi::settings()->get('qrcode_events');
+    $qrcode_events = \Civi::settings()->get('qrcode_events') ?? [];
     if ($qrcode_enabled_event) {
       // Add event ID to array of QR-enabled
       if (!in_array($event_id, $qrcode_events)) {


### PR DESCRIPTION
We've had the extension cause fatal errors in a multisite/domain installation. A fresh installation of the extension led to fatal errors for users when trying to create new events, or open existing events.

The enabling/installation of the extension in _one_ domain did work as expected in that one domain, but not the others.

This PR/patch is a small one that simply safeguards against fatal error. It seems like a good safeguard generally, and means we can defer consideration of more explicit multisite support (or refactoring the settings pattern more broadly) for another time.

We've deployed the change and confirmed it works